### PR TITLE
YouTubeFeedの型定義の追加

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { XMLParser } from 'fast-xml-parser';
+import { YouTubeFeed } from './types/youtubeXmlInterface';
 
 const app = new Hono();
 
@@ -15,7 +16,7 @@ app.get('/websub/youtube', (context) => {
 app.post('/websub/youtube', async (context) => {
   const body = await context.req.text();
   const parser = new XMLParser();
-  const xml = parser.parse(body);
+  const xml = parser.parse(body) as YouTubeFeed;
 
   // xmlの構造は https://www.youtube.com/feeds/videos.xml?channel_id=UC_aBYQ3phPsrkSXkpnZeDZw
 

--- a/src/types/youtubeXmlInterface.ts
+++ b/src/types/youtubeXmlInterface.ts
@@ -1,0 +1,100 @@
+/**
+ * `media:starRating`要素の型
+ */
+export interface MediaStarRating {
+  count: number;
+  average: number;
+  min: number;
+  max: number;
+}
+
+/**
+ * `media:statistics`要素の型
+ */
+export interface MediaStatistics {
+  views: number;
+}
+
+/**
+ * `media:community`要素の型
+ */
+export interface MediaCommunity {
+  'media:starRating': MediaStarRating;
+  'media:statistics': MediaStatistics;
+}
+
+/**
+ * `media:content`要素の型
+ */
+export interface MediaContent {
+  url: string;
+  type: string;
+  width: number;
+  height: number;
+}
+
+/**
+ * `media:thumbnail`要素の型
+ */
+export interface MediaThumbnail {
+  url: string;
+  width: number;
+  height: number;
+}
+
+/**
+ * `media:group`要素の型
+ */
+export interface MediaGroup {
+  'media:title': string;
+  'media:content': MediaContent;
+  'media:thumbnail': MediaThumbnail;
+  'media:description': string;
+  'media:community': MediaCommunity;
+}
+
+/**
+ * `author`要素の型
+ */
+export interface Author {
+  name: string;
+  uri: string;
+}
+
+/**
+ * `link`要素の型
+ */
+export interface Link {
+  rel: string;
+  href: string;
+}
+
+/**
+ * `entry`要素（各動画）の型
+ */
+export interface VideoEntry {
+  id: string;
+  'yt:videoId': string;
+  'yt:channelId': string;
+  title: string;
+  link: Link;
+  author: Author;
+  published: string;
+  updated: string;
+  'media:group': MediaGroup;
+}
+
+/**
+ * ルート要素である`feed`の型
+ */
+export interface YouTubeFeed {
+  feed: {
+    link: Link[];
+    id: string;
+    'yt:channelId': string;
+    title: string;
+    author: Author;
+    published: string;
+    entry: VideoEntry[];
+  };
+}


### PR DESCRIPTION
# やったこと

- YouTubeFeedの型定義の追加
- xmlのパース結果オブジェクトに対して片付け

# レビュー観点

- 型定義ファイルの配置ディレクトリ名、場所

# 注意事項

- 型定義は雑にAIで生成して確認していないので、間違っているかも