### PR TITLE
workers周りの設定更新

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,9 +3,13 @@
   "name": "higuma-notify",
   "main": "src/index.ts",
   "compatibility_date": "2025-08-22",
-  // "compatibility_flags": [
-  //   "nodejs_compat"
-  // ],
+  "compatibility_flags": [
+    "nodejs_compat"
+  ],
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  }
   // "vars": {
   //   "MY_VAR": "my-variable"
   // },
@@ -31,8 +35,4 @@
   // "ai": {
   //   "binding": "AI"
   // },
-  // "observability": {
-  //   "enabled": true,
-  //   "head_sampling_rate": 1
-  // }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,36 +3,9 @@
   "name": "higuma-notify",
   "main": "src/index.ts",
   "compatibility_date": "2025-08-22",
-  "compatibility_flags": [
-    "nodejs_compat"
-  ],
+  "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true,
-    "head_sampling_rate": 1
-  }
-  // "vars": {
-  //   "MY_VAR": "my-variable"
-  // },
-  // "kv_namespaces": [
-  //   {
-  //     "binding": "MY_KV_NAMESPACE",
-  //     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-  //   }
-  // ],
-  // "r2_buckets": [
-  //   {
-  //     "binding": "MY_BUCKET",
-  //     "bucket_name": "my-bucket"
-  //   }
-  // ],
-  // "d1_databases": [
-  //   {
-  //     "binding": "MY_DB",
-  //     "database_name": "my-database",
-  //     "database_id": ""
-  //   }
-  // ],
-  // "ai": {
-  //   "binding": "AI"
-  // },
+    "head_sampling_rate": 1,
+  },
 }


### PR DESCRIPTION
# 背景
デプロイ時にコケてしまうので、その対応。
```log

13:04:55.839 | ▲ [WARNING] The package "node:util" wasn't found on the file system but is built into node.
-- | --
13:04:55.840 |  
13:04:55.840 | Your Worker may throw errors at runtime unless you enable the "nodejs_compat" compatibility flag. Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details. Imported from:
13:04:55.840 | - src/index.ts
13:04:55.840 |  
13:04:55.841 |  
13:04:55.864 | Total Upload: 537.73 KiB / gzip: 87.12 KiB
13:04:57.625 |  
13:04:57.627 | ✘ [ERROR] A request to the Cloudflare API (/accounts/2e59fbed9c44667c5b2e387693433f91/workers/scripts/higuma-notify/versions) failed.
13:04:57.627 |  
13:04:57.627 | Uncaught Error: No such module "node:util".
13:04:57.627 | imported from "index.js"
13:04:57.627 | [code: 10021]

```

# 確認したこと
以下のページを確認
- https://developers.cloudflare.com/workers/runtime-apis/nodejs/
- https://developers.cloudflare.com/workers/runtime-apis/nodejs/util/
  - To enable built-in Node.js APIs and polyfills, add the nodejs_compat compatibility flag to your [Wrangler configuration file](https://developers.cloudflare.com/workers/wrangler/configuration/). This also enables nodejs_compat_v2 as long as your compatibility date is 2024-09-23 or later. [Learn more about the Node.js compatibility flag and v2](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#nodejs-compatibility-flag).

# 対応内容
- nodejs_compatを設定に追加。ビルドエラー回避のため
- logの有効化。今までの設定をサボっていたため。今回のタイミングで。。
- cloudflare側の設定でmainブランチ以外でもビルドを走らせるようにした。ビルドエラーを検知するため。