### PR TITLE
POST `/websub/youtube` に来たリクエストに対して `X-Hub-Signature` ヘッダの値を検証する

### DIFF
--- a/.github/workflows/send-notification.yml
+++ b/.github/workflows/send-notification.yml
@@ -29,9 +29,6 @@ on:
           </feed>
         type: string
 
-permissions:
-  contents: read
-
 jobs:
   subscribe:
     runs-on: ubuntu-latest

--- a/.github/workflows/send-notification.yml
+++ b/.github/workflows/send-notification.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       payload:
-        description: "Payload to send to HUB_CALLBACK. When omitted, a default payload will be used."
+        description: 'Payload to send to HUB_CALLBACK. When omitted, a default payload will be used.'
         required: false
         default: |
           <feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"
@@ -45,7 +45,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-          
+
       - name: Run the send notification script
         run: bun run tools/send-notification.ts
         env:

--- a/.github/workflows/send-notification.yml
+++ b/.github/workflows/send-notification.yml
@@ -1,0 +1,54 @@
+name: send notification
+
+on:
+  workflow_dispatch:
+    inputs:
+      payload:
+        description: "Payload to send to HUB_CALLBACK. When omitted, a default payload will be used."
+        required: false
+        default: |
+          <feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+                xmlns="http://www.w3.org/2005/Atom">
+            <link rel="hub" href="https://pubsubhubbub.appspot.com"/>
+            <link rel="self" href="https://www.youtube.com/xml/feeds/videos.xml?channel_id=CHANNEL_ID"/>
+            <title>YouTube video feed</title>
+            <updated>2015-04-01T19:05:24.552394234+00:00</updated>
+            <entry>
+              <id>yt:video:VIDEO_ID</id>
+              <yt:videoId>VIDEO_ID</yt:videoId>
+              <yt:channelId>CHANNEL_ID</yt:channelId>
+              <title>Video title</title>
+              <link rel="alternate" href="http://www.youtube.com/watch?v=VIDEO_ID"/>
+              <author>
+               <name>Channel title</name>
+               <uri>http://www.youtube.com/channel/CHANNEL_ID</uri>
+              </author>
+              <published>2015-03-06T21:40:57+00:00</published>
+              <updated>2015-03-09T19:05:24.552394234+00:00</updated>
+            </entry>
+          </feed>
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  subscribe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+          
+      - name: Run the send notification script
+        run: bun run tools/send-notification.ts
+        env:
+          PAYLOAD: ${{ inputs.payload }}
+          HUB_CALLBACK: ${{ secrets.HUB_CALLBACK }}
+          HUB_SECRET: ${{ secrets.HUB_SECRET }}

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ YouTube の PubSubHubbub（WebSub）Hub に対し、以下のフォームパラ�
 - hub.mode: `subscribe`
 - hub.topic: `https://www.youtube.com/feeds/videos.xml?channel_id=<YourChannelId>`
 - hub.callback: あなたの公開コールバック URL（例: `https://<your-domain>/websub/youtube`）
-- hub.secret: 任意（署名用）。現状このプロジェクトでは署名検証を行っていません
+- hub.secret: 任意（署名用）。このプロジェクトでは署名検証を行っており、POST `/websub/youtube` へのリクエストを受け取った際、リクエストヘッダーの `X-Hub-Signature` が期待する値であることを確認しています。詳細な仕様は [PubSubHubbub Core 0.4 - 8. Authenticated Content Distribution](https://pubsubhubbub.github.io/PubSubHubbub/pubsubhubbub-core-0.4.html#rfc.section.8) を参照してください
 - hub.lease_seconds: 任意（購読期間）
 
 購読するコマンド例

--- a/src/UseHomareHandler.ts
+++ b/src/UseHomareHandler.ts
@@ -45,13 +45,20 @@ export const useHomareHandler = () => {
   /**
    * 痺れますね！
    */
-  const postShibireMasuNeNotification = async (context: Context, notificationMessage: string) => {
+  const postShibireMasuNeNotification = async (
+    // リクエストボディは Signature を検証する際にすでに読み取られており、context.req.text() などで再読取りを
+    // しようとすると Body already consumed エラーが発生してしまう
+    // そのため、req を明示的に除外して、誤って context.req を触ったら型エラーになるようにする
+    // リクエストボディを利用する場合は、第3引数の reqBody を使う
+    context: Omit<HigumaContext, 'req'>,
+    notificationMessage: string,
+    reqBody: string
+  ) => {
     const { createDiscordNotification, sendDiscordNotification }: UseDiscordNotification =
       useDiscordNotification();
 
     // parse YouTube feed from context using Result pattern
-    const contextBody: string = await context.req.text();
-    const youTubeFeedParseResult: YouTubeFeedParseResult = tryParseYouTubeFeed(contextBody);
+    const youTubeFeedParseResult: YouTubeFeedParseResult = tryParseYouTubeFeed(reqBody);
     if (!youTubeFeedParseResult.success) {
       // 「XMLパース失敗」 or 「XML検証失敗」時の Error の処理
       return context.json({ status: 'fail..', error: youTubeFeedParseResult.error.message }, 400);
@@ -65,7 +72,7 @@ export const useHomareHandler = () => {
     );
 
     // send discord notification
-    const webhookUrl: string = (context.env as { DISCORD_WEBHOOK_URL: string }).DISCORD_WEBHOOK_URL;
+    const webhookUrl: string = context.env.DISCORD_WEBHOOK_URL;
     return await sendDiscordNotification(webhookUrl, discordNotification)
       .then(() => {
         return context.json({ status: 'success', message: 'Discord通知送信成功' });

--- a/src/UseHomareHandler.ts
+++ b/src/UseHomareHandler.ts
@@ -1,4 +1,3 @@
-import { Context } from 'hono';
 import { DiscordNotification } from './types/DiscordNotification';
 import {
   useDiscordNotification,

--- a/src/UseHomareHandler.ts
+++ b/src/UseHomareHandler.ts
@@ -7,6 +7,7 @@ import {
 } from './UseDiscordNotification';
 import { YouTubeFeed } from './types/YouTubeFeed';
 import { useYouTubeFeed, YouTubeFeedParseError, UseYouTubeFeed } from './UseYouTubeFeed';
+import type { HigumaContext } from './types/Context';
 
 export const useHomareHandler = () => {
   // Result type for parsing YouTube feed
@@ -34,7 +35,7 @@ export const useHomareHandler = () => {
   /**
    * 闘う顔してますか？
    */
-  const battleFaceOk = (context: Context) => {
+  const battleFaceOk = (context: HigumaContext) => {
     const query: string = context.req.query('hub.challenge') ?? 'empty';
     console.log(query);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,11 @@ app.post('/websub/youtube', async (context: HigumaContext) => {
   const reqBody = await context.req.text();
 
   // X-Hub-Signature を検証
-  validateSignature(context.req.header(), reqBody, context.env.HUB_SECRET);
+  validateSignature({
+    xHubSignature: context.req.header('x-hub-signature'),
+    reqBody,
+    hubSecret: context.env.HUB_SECRET,
+  });
 
   // ランダムな通知メッセージを生成
   const { generateRandomNotificationMessage }: UseRandomNotificationMessage =

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
-import { Hono, Context } from 'hono';
+import { Hono } from 'hono';
 import { inspect } from 'node:util';
-import { Bindings } from './types/Bindings';
+import type { Bindings } from './types/Bindings';
+import type { HigumaContext } from './types/Context';
 import { useHomareHandler, UseHomareHandler } from './UseHomareHandler';
 import {
   useRandomNotificationMessage,
@@ -17,7 +18,7 @@ const { battleFaceOk, postShibireMasuNeNotification }: UseHomareHandler = useHom
 const app = new Hono<{ Bindings: Bindings }>();
 
 // 1) 確認リクエスト (GET)
-app.get('/websub/youtube', (context: Context) => {
+app.get('/websub/youtube', (context: HigumaContext) => {
   /**
    * 闘う顔してますか？
    */
@@ -25,7 +26,7 @@ app.get('/websub/youtube', (context: Context) => {
 });
 
 // 2) 投稿リクエスト (POST) with rate limiting
-app.post('/websub/youtube', async (context: Context) => {
+app.post('/websub/youtube', async (context: HigumaContext) => {
   // RateLimit のバリデーションチェック
   await validateRateLimit(context);
 
@@ -40,7 +41,7 @@ app.post('/websub/youtube', async (context: Context) => {
 });
 
 // 999) catch all exceptional errors
-app.onError((error: Error, context: Context) => {
+app.onError((error: Error, context: HigumaContext) => {
   console.error(`${inspect(error)}`);
   return context.json({ message: '類例をみないエラー', error: error.message }, 500);
 });

--- a/src/types/Bindings.ts
+++ b/src/types/Bindings.ts
@@ -2,4 +2,5 @@ export type Bindings = {
   DISCORD_WEBHOOK_URL: string;
   RATE_LIMITER: RateLimit;
   HIGUMA_NOTIFY_KV: KVNamespace;
+  HUB_SECRET: string;
 };

--- a/src/types/Context.ts
+++ b/src/types/Context.ts
@@ -1,0 +1,4 @@
+import type { Context } from 'hono';
+import type { Bindings } from './Bindings';
+
+export type HigumaContext = Context<{ Bindings: Bindings }>;

--- a/src/validation/RateLimitValidation.ts
+++ b/src/validation/RateLimitValidation.ts
@@ -1,5 +1,4 @@
-import { Context } from 'hono';
-import { Bindings } from '../types/Bindings';
+import type { HigumaContext } from '../types/Context';
 
 export class RateLimitExceededError extends Error {
   constructor(message = 'Rate limit exceeded') {
@@ -8,9 +7,7 @@ export class RateLimitExceededError extends Error {
   }
 }
 
-export const validateRateLimit = async (
-  context: Context<{ Bindings: Bindings }>
-): Promise<void> => {
+export const validateRateLimit = async (context: HigumaContext): Promise<void> => {
   const rateLimiter = context.env.RATE_LIMITER;
   // CF-Connecting-IP は Cloudflare が直接設定するため改竄されにくい
   const clientIP = context.req.header('CF-Connecting-IP') || 'unknown';

--- a/src/validation/SignatureValidation.ts
+++ b/src/validation/SignatureValidation.ts
@@ -6,18 +6,21 @@ export class InvalidSignatureError extends Error {
   }
 }
 
-export function validateSignature(
-  headers: Record<string, string>,
-  reqBody: string,
-  hubSecret: string
-) {
-  const sig = headers['X-Hub-Signature'];
-  if (!sig) {
+export function validateSignature({
+  xHubSignature,
+  reqBody,
+  hubSecret,
+}: {
+  xHubSignature?: string;
+  reqBody: string;
+  hubSecret: string;
+}) {
+  if (!xHubSignature) {
     throw new InvalidSignatureError('X-Hub-Signature header is missing');
   }
 
   // X-Hub-Signature header starts with 'sha1=' prefix; strip it
-  const [, got] = sig.split('=');
+  const [, got] = xHubSignature.split('=');
   const expected = createHmac('sha1', hubSecret).update(reqBody).digest('hex');
   if (got !== expected) {
     throw new InvalidSignatureError(`Signature mismatch: expected ${expected}, got ${got}`);

--- a/src/validation/SignatureValidation.ts
+++ b/src/validation/SignatureValidation.ts
@@ -1,0 +1,25 @@
+import { createHmac } from 'node:crypto';
+
+export class InvalidSignatureError extends Error {
+  static {
+    this.prototype.name = 'InvalidSignatureError';
+  }
+}
+
+export function validateSignature(
+  headers: Record<string, string>,
+  reqBody: string,
+  hubSecret: string
+) {
+  const sig = headers['X-Hub-Signature'];
+  if (!sig) {
+    throw new InvalidSignatureError('X-Hub-Signature header is missing');
+  }
+
+  // X-Hub-Signature header starts with 'sha1=' prefix; strip it
+  const [, got] = sig.split('=');
+  const expected = createHmac('sha1', hubSecret).update(reqBody).digest('hex');
+  if (got !== expected) {
+    throw new InvalidSignatureError(`Signature mismatch: expected ${expected}, got ${got}`);
+  }
+}

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -177,27 +177,30 @@ describe('Unit Tests', () => {
 
   describe('Signature Validation Tests', () => {
     it('should throw InvalidSignatureError when X-Hub-Signature header is missing', () => {
-      const headers = {
-        /* no X-Hub-Signature header */
-      };
-      const reqBody = 'test';
-      const hubSecret = 'test';
-      expect(() => validateSignature(headers, reqBody, hubSecret)).toThrow(InvalidSignatureError);
+      expect(() =>
+        validateSignature({ xHubSignature: undefined, reqBody: 'test', hubSecret: 'test' })
+      ).toThrow(InvalidSignatureError);
+    });
+
+    it('should throw InvalidSignatureError when X-Hub-Signature header is empty', () => {
+      expect(() =>
+        validateSignature({ xHubSignature: '', reqBody: 'test', hubSecret: 'test' })
+      ).toThrow(InvalidSignatureError);
     });
 
     it('should throw InvalidSignatureError when the signature does not match', () => {
-      const headers = { 'X-Hub-Signature': 'sha1=invalid' };
-      const reqBody = 'test';
-      const hubSecret = 'test';
-      expect(() => validateSignature(headers, reqBody, hubSecret)).toThrow(InvalidSignatureError);
+      expect(() =>
+        validateSignature({ xHubSignature: 'sha1=invalid', reqBody: 'test', hubSecret: 'test' })
+      ).toThrow(InvalidSignatureError);
     });
 
     it('should not throw an error when the signature matches', () => {
       const hubSecret = 'secret';
       const reqBody = 'foobar';
       const hmac = createHmac('sha1', hubSecret).update(reqBody).digest('hex');
-      const headers = { 'X-Hub-Signature': `sha1=${hmac}` };
-      expect(() => validateSignature(headers, reqBody, hubSecret)).not.toThrow();
+      expect(() =>
+        validateSignature({ xHubSignature: `sha1=${hmac}`, reqBody, hubSecret })
+      ).not.toThrow();
     });
   });
 });

--- a/tools/send-notification.ts
+++ b/tools/send-notification.ts
@@ -1,0 +1,30 @@
+import { createHmac } from "node:crypto";
+
+function stringEnv(name: string): string {
+    const value = process.env[name];
+    if (!value) {
+        throw new Error(`Environment variable ${name} is required`);
+    }
+    return value;
+}
+
+const HUB_CALLBACK = stringEnv("HUB_CALLBACK");
+const HUB_SECRET = stringEnv("HUB_SECRET");
+const PAYLOAD = stringEnv("PAYLOAD");
+
+const hmac = createHmac("sha1", HUB_SECRET).update(PAYLOAD).digest("hex");
+
+const res = await fetch(HUB_CALLBACK, {
+    method: "POST",
+    headers: {
+        "Content-Type": "application/atom+xml",
+        "X-Hub-Signature": `sha1=${hmac}`,
+    },
+    body: PAYLOAD,
+});
+
+const resBody = await res.text();
+console.log({
+    status: res.status,
+    resBody,
+});

--- a/tools/send-notification.ts
+++ b/tools/send-notification.ts
@@ -18,7 +18,7 @@ const hmac = createHmac('sha1', HUB_SECRET).update(PAYLOAD).digest('hex');
 const res = await fetch(HUB_CALLBACK, {
   method: 'POST',
   headers: {
-    'Content-Type': 'text/xml; charset=UTF-8',
+    'Content-Type': 'application/atom+xml',
     'X-Hub-Signature': `sha1=${hmac}`,
   },
   body: PAYLOAD,

--- a/tools/send-notification.ts
+++ b/tools/send-notification.ts
@@ -18,7 +18,7 @@ const hmac = createHmac('sha1', HUB_SECRET).update(PAYLOAD).digest('hex');
 const res = await fetch(HUB_CALLBACK, {
   method: 'POST',
   headers: {
-    'Content-Type': 'application/atom+xml',
+    'Content-Type': 'text/xml; charset=UTF-8',
     'X-Hub-Signature': `sha1=${hmac}`,
   },
   body: PAYLOAD,

--- a/tools/send-notification.ts
+++ b/tools/send-notification.ts
@@ -1,4 +1,5 @@
 import { createHmac } from 'node:crypto';
+import process from 'node:process';
 
 function stringEnv(name: string): string {
   const value = process.env[name];

--- a/tools/send-notification.ts
+++ b/tools/send-notification.ts
@@ -1,30 +1,30 @@
-import { createHmac } from "node:crypto";
+import { createHmac } from 'node:crypto';
 
 function stringEnv(name: string): string {
-    const value = process.env[name];
-    if (!value) {
-        throw new Error(`Environment variable ${name} is required`);
-    }
-    return value;
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Environment variable ${name} is required`);
+  }
+  return value;
 }
 
-const HUB_CALLBACK = stringEnv("HUB_CALLBACK");
-const HUB_SECRET = stringEnv("HUB_SECRET");
-const PAYLOAD = stringEnv("PAYLOAD");
+const HUB_CALLBACK = stringEnv('HUB_CALLBACK');
+const HUB_SECRET = stringEnv('HUB_SECRET');
+const PAYLOAD = stringEnv('PAYLOAD');
 
-const hmac = createHmac("sha1", HUB_SECRET).update(PAYLOAD).digest("hex");
+const hmac = createHmac('sha1', HUB_SECRET).update(PAYLOAD).digest('hex');
 
 const res = await fetch(HUB_CALLBACK, {
-    method: "POST",
-    headers: {
-        "Content-Type": "application/atom+xml",
-        "X-Hub-Signature": `sha1=${hmac}`,
-    },
-    body: PAYLOAD,
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/atom+xml',
+    'X-Hub-Signature': `sha1=${hmac}`,
+  },
+  body: PAYLOAD,
 });
 
 const resBody = await res.text();
 console.log({
-    status: res.status,
-    resBody,
+  status: res.status,
+  resBody,
 });


### PR DESCRIPTION
- 署名検証: POST `/websub/youtube` で `X-Hub-Signature`（HMAC-SHA1）を検証し、検証失敗時には "JKでも分かる不正融資のようなエラー" をステータスコード400で返却。合わせて、READMEの修正およびユニットテストを追加
- 検証用ツール: 署名付き通知を送れる GitHub Actions ワークフローを追加
- 型の整備: `HigumaContext` と `Bindings.HUB_SECRET` を導入し、環境変数に対する型付けを強化

Closes #55